### PR TITLE
Select Limited fields in the translations

### DIFF
--- a/lib/i18n/backend/sequel_bitemporal/translation.rb
+++ b/lib/i18n/backend/sequel_bitemporal/translation.rb
@@ -143,7 +143,12 @@ module I18n
           end
 
           def all_for_locale(locale)
-            self.locale(locale).with_current_version.all
+            self.locale(locale).with_current_version.select(
+              :locale,
+              :key,
+              :value,
+              :is_proc
+            ).all
           end
         end
       end


### PR DESCRIPTION
Serializing Ruby's Time/DateTime is not fast, and the Time/DateTime attributes are useless when we just want to use the translations for read-only.

When we want to update a translation, the method `store_translations` always loads the translation from the database with all the attributes, so I think the changes in this MR won't impact the logic of updating.